### PR TITLE
Links on start page

### DIFF
--- a/app/views/beta/phase-5/index.html
+++ b/app/views/beta/phase-5/index.html
@@ -81,16 +81,16 @@ A guide to buying and procuring for schools.
 
     <p>There are rules about which processes you can follow depending on how much you're spending. Other factors like how much time you have may influence your decision.</p>
 
-    <p>Make sure you've completed the <a href="#">Find the right procurement process</a> step before you continue.</p>
+    <p>Make sure you've completed the <a href="./first-steps/find-the-right-procurement-process.html">Find the right procurement process</a> step before you continue.</p>
 
     <ul class="govuk-list">
      <li>
         <h3 class="govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="next-steps/choose-a-supplier">Choose a supplier from a framework, step by step</a></h3>
-        <p>How to use <a href="https://www.gov.uk/guidance/find-a-dfe-approved-framework-for-your-school">Find a framework</a> to select a quality-checked supplier. Frameworks use pre-written terms and conditions that are approved by DfE.</p>
+        <p>How to use Find a framework to select a quality-checked supplier. Frameworks use pre-written terms and conditions that are approved by DfE.</p>
      </li>
      <li>
         <h3 class="govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="next-steps/run-a-mini-competition">Run a mini competition from a framework, step by step</a></h3>
-        <p>How to use <a href="https://www.gov.uk/guidance/find-a-dfe-approved-framework-for-your-school">Find a framework</a> to get 3 quotes from quality-checked suppliers. Frameworks use pre-written terms and conditions that are approved by DfE.</p>
+        <p>How to use Find a framework to get 3 quotes from quality-checked suppliers. Frameworks use pre-written terms and conditions that are approved by DfE.</p>
      </li>
      <li>
         <h3 class="govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline" href="next-steps/get-at-least-3-quotes">Get at least 3 quotes from suppliers, step by step</a></h3>


### PR DESCRIPTION
- Removed links to FaF under the 'next steps' headings as they distract from the navigation
- Added a link to 'Find the right procurement process' under next steps